### PR TITLE
Minor fixes for manual tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include src/pyskindose/settings_example.json
 include src/pyskindose/table_data/*.csv
 include src/pyskindose/phantom_data/*.stl
 include src/pyskindose/example_data/RDSR/*.dcm
+include src/pyskindose/normalization_settings.json

--- a/src/pyskindose/dev_data.py
+++ b/src/pyskindose/dev_data.py
@@ -5,7 +5,7 @@ DEVELOPMENT_PARAMETERS = dict(
     # modes: 'calculate_dose', 'plot_setup', 'plot_event', 'plot_procedure'
     mode=c.MODE_PLOT_PROCEDURE,
     # RDSR filename
-    rdsr_filename='s1.dcm',
+    rdsr_filename='S1.dcm',
     # Set True to estimate table correction, or False to use measured k_tab
     estimate_k_tab=False,
     # Numeric value of estimated table correction

--- a/tests/manual_tests/base_dev_settings.py
+++ b/tests/manual_tests/base_dev_settings.py
@@ -4,7 +4,7 @@ DEVELOPMENT_PARAMETERS = dict(
     # modes: 'calculate_dose', 'plot_setup', 'plot_event', 'plot_procedure'
     mode=c.MODE_PLOT_PROCEDURE,
     # RDSR filename
-    rdsr_filename='s1.dcm',
+    rdsr_filename='S1.dcm',
     # Irrading event index for mode='plot_event'
     plot_event_index=12,
     # Set True to estimate table correction, or False to use measured k_tab

--- a/tests/manual_tests/notebook_tests/notebook_base_dev_settings.py
+++ b/tests/manual_tests/notebook_tests/notebook_base_dev_settings.py
@@ -4,7 +4,7 @@ DEVELOPMENT_PARAMETERS = dict(
     # modes: 'calculate_dose', 'plot_setup', 'plot_event', 'plot_procedure'
     mode=c.MODE_PLOT_PROCEDURE,
     # RDSR filename
-    rdsr_filename='s1.dcm',
+    rdsr_filename='S1.dcm',
     # Set True to estimate table correction, or False to use measured k_tab
     estimate_k_tab=False,
     # Numeric value of estimated table correction


### PR DESCRIPTION
While trying some of the tests in `tests/manual_tests`, I encountered a few FileNotFoundErrors because:

- the settings file points to `s1.dcm` but the example data folder contains `S1.dcm`
  + maybe this would've worked fine on an operating system with case-insensitive paths
  + resolved by changing the filename in the settings files
- [rdsr_normalizer](https://github.com/rvbCMTS/PySkinDose/blob/1e6e05ee842662d49234583dd4709c06a536a0ac/src/pyskindose/rdsr_normalizer.py#L119-L120) couldn't find the `normalization_settings.json` file because it wasn't copied over during the package installation
  + resolved by adding the settings json file into `MANIFEST.in`