### PR TITLE
Add correction table path setting

### DIFF
--- a/src/pyskindose/calculate_dose/add_correction_and_event_dose_to_output.py
+++ b/src/pyskindose/calculate_dose/add_correction_and_event_dose_to_output.py
@@ -21,6 +21,7 @@ def add_corrections_and_event_dose_to_output(
     back_scatter_interpolation: List[CubicSpline],
     field_area: List[float],
     k_tab: List[float],
+    corrections_db: str,
     output: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Add correction factors and event dose to output dictionary.
@@ -49,6 +50,8 @@ def add_corrections_and_event_dose_to_output(
         beam
     k_tab : List[float]
         List of table correction factors
+    corrections_db : str
+        A string defining the path to the corrections SQLite db
     output : Dict[str, Any]
         Dictionary containing outputs to store from the calculations. E.g. dose map and
         correction factors.
@@ -69,7 +72,11 @@ def add_corrections_and_event_dose_to_output(
     k_bs = back_scatter_interpolation[event](np.sqrt(field_area))
 
     logger.debug("Calculating reference point medium correction (air -> water)")
-    k_med = calculate_k_med(data_norm=normalized_data, field_area=field_area, event=event)
+    k_med = calculate_k_med(
+        data_norm=normalized_data,
+        field_area=field_area,
+        event=event,
+        corrections_db=corrections_db)
 
     output[c.OUTPUT_KEY_CORRECTION_BACK_SCATTER][event] = k_bs
     output[c.OUTPUT_KEY_CORRECTION_MEDIUM][event] = k_med

--- a/src/pyskindose/calculate_dose/calculate_dose.py
+++ b/src/pyskindose/calculate_dose/calculate_dose.py
@@ -89,6 +89,7 @@ def calculate_dose(
         data_norm=normalized_data,
         estimate_k_tab=settings.estimate_k_tab,
         k_tab_val=settings.k_tab_val,
+        corrections_db=settings.corrections_db_path
     )
 
     total_number_of_events = len(normalized_data)

--- a/src/pyskindose/calculate_dose/calculate_dose.py
+++ b/src/pyskindose/calculate_dose/calculate_dose.py
@@ -72,7 +72,11 @@ def calculate_dose(
         patient_orientation=settings.phantom.patient_orientation,
     )
 
-    normalized_data = fetch_and_append_hvl(data_norm=normalized_data, inherent_filtration=settings.inherent_filtration)
+    normalized_data = fetch_and_append_hvl(
+        data_norm=normalized_data,
+        inherent_filtration=settings.inherent_filtration,
+        corrections_db=settings.corrections_db_path
+    )
 
     # Check which irradiation events that contains updated
     # geometry parameters since the previous irradiation event
@@ -117,6 +121,7 @@ def calculate_dose(
         back_scatter_interpolation=back_scatter_interpolation,
         output=output_template,
         pbar=pbar(total=total_number_of_events, leave=False, desc="calculating skindose"),
+        corrections_db=settings.corrections_db_path
     )
 
     return patient, output

--- a/src/pyskindose/calculate_dose/calculate_irradiation_event_result.py
+++ b/src/pyskindose/calculate_dose/calculate_irradiation_event_result.py
@@ -119,6 +119,7 @@ def calculate_irradiation_event_result(
         field_area=field_area,
         k_tab=k_tab,
         output=output,
+        corrections_db=corrections_db,
     )
 
     event += 1

--- a/src/pyskindose/calculate_dose/calculate_irradiation_event_result.py
+++ b/src/pyskindose/calculate_dose/calculate_irradiation_event_result.py
@@ -30,6 +30,7 @@ def calculate_irradiation_event_result(
     pad: Phantom,
     back_scatter_interpolation: List[CubicSpline],
     output: Dict[str, Any],
+    corrections_db: str,
     table_hits: List[bool] = None,
     field_area: List[float] = None,
     k_isq: np.array = None,
@@ -68,6 +69,8 @@ def calculate_irradiation_event_result(
     output : Dict[str, Any]
         Dictionary containing outputs to store from the calculations. E.g. dose map and
         correction factors.
+    corrections_db : str
+        A string defining the path to the corrections SQLite db
     table_hits : List[bool], optional
         A boolean list that specfies (for each hit), if the bean passes through the
         patient support table, by default None
@@ -135,6 +138,7 @@ def calculate_irradiation_event_result(
             pad=pad,
             back_scatter_interpolation=back_scatter_interpolation,
             output=output,
+            corrections_db=corrections_db,
             table_hits=table_hits,
             field_area=field_area,
             k_isq=k_isq,

--- a/src/pyskindose/corrections.py
+++ b/src/pyskindose/corrections.py
@@ -98,7 +98,7 @@ def calculate_k_bs(data_norm: pd.DataFrame) -> List[CubicSpline]:
     return bs_interp
 
 
-def calculate_k_med(data_norm: pd.DataFrame, field_area: List[float], event: int) -> float:
+def calculate_k_med(data_norm: pd.DataFrame, field_area: List[float], event: int, corrections_db: str) -> float:
     """Calculate medium correction.
 
     This function calculates and appends the medium correction factor for all skin cells
@@ -115,6 +115,9 @@ def calculate_k_med(data_norm: pd.DataFrame, field_area: List[float], event: int
         beam.
     event : int
         Irradiation event index.
+    corrections_db : str
+        A string defining the path to the corrections SQLite db
+
 
     Returns
     -------
@@ -138,7 +141,7 @@ def calculate_k_med(data_norm: pd.DataFrame, field_area: List[float], event: int
     fsl = min(fsl_tab, key=lambda x: abs(x - fsl_mean))
 
     # Connect to database
-    conn = db_connect()[0]
+    conn = db_connect(db_name=corrections_db)[0]
 
     # Fetch k_med = f(kVp, HVL) from database. This is table 2 in
     # [doi:10.1088/0031-9155/58/2/247]
@@ -173,7 +176,7 @@ def calculate_k_med(data_norm: pd.DataFrame, field_area: List[float], event: int
     return k_med
 
 
-def calculate_k_tab(data_norm: pd.DataFrame, estimate_k_tab: bool = False, k_tab_val: float = 0.8) -> List[float]:
+def calculate_k_tab(data_norm: pd.DataFrame, corrections_db: str, estimate_k_tab: bool = False, k_tab_val: float = 0.8) -> List[float]:
     """Fetch table correction factor from database.
 
     This function fetches measured table correction factor as a function of
@@ -188,6 +191,8 @@ def calculate_k_tab(data_norm: pd.DataFrame, estimate_k_tab: bool = False, k_tab
         Set to True to use estimated table correction, default is False.
     k_tab_val: float
         Value of estimated table corrections, must be in range (0, 1).
+    corrections_db : str
+        A string defining the path to the corrections SQLite db
 
     Returns
     -------
@@ -199,7 +204,7 @@ def calculate_k_tab(data_norm: pd.DataFrame, estimate_k_tab: bool = False, k_tab
         return [k_tab_val] * len(data_norm)
 
     # Connect to database
-    [conn, c] = db_connect()
+    [conn, c] = db_connect(db_name=corrections_db)
 
     k_tab = [1.0] * len(data_norm)
 

--- a/src/pyskindose/db_connect.py
+++ b/src/pyskindose/db_connect.py
@@ -1,10 +1,13 @@
+import logging
 import os
 import sqlite3
 
 import pandas as pd
 
+logger = logging.getLogger("pyskindose")
 
-def db_connect(db_name: str = "corrections.db"):
+
+def db_connect(db_name: str):
     """Set up the database connection with tables needed for PSD calculations.
 
     Parameters
@@ -27,10 +30,14 @@ def db_connect(db_name: str = "corrections.db"):
         db_exist = True
 
     # Connect to database
-    conn = sqlite3.connect(db_name)
+    try:
+        conn = sqlite3.connect(db_name)
 
-    # Create cursor (enables sql commands using the sql method)
-    cursor = conn.cursor()
+        # Create cursor (enables sql commands using the sql method)
+        cursor = conn.cursor()
+    except sqlite3.Error as e:
+        logger.error("Failed to connect to/create database at {}".format(db_name), exc_info=True)
+        raise
 
     if not db_exist:
 

--- a/src/pyskindose/geom_calc.py
+++ b/src/pyskindose/geom_calc.py
@@ -218,7 +218,7 @@ def scale_field_area(
     return field_area
 
 
-def fetch_and_append_hvl(data_norm: pd.DataFrame, inherent_filtration: float) -> pd.DataFrame:
+def fetch_and_append_hvl(data_norm: pd.DataFrame, inherent_filtration: float, corrections_db: str) -> pd.DataFrame:
     """Add event HVL to RDSR event data from database.
 
     Parameters
@@ -227,6 +227,8 @@ def fetch_and_append_hvl(data_norm: pd.DataFrame, inherent_filtration: float) ->
         RDSR data, normalized for compliance with PySkinDose.
     inherent_filtration : float
         X-ray tube inherent filtration in mmAl.
+    corrections_db : str
+        A string defining the path to the corrections SQLite db
 
     Returns
     -------
@@ -237,7 +239,7 @@ def fetch_and_append_hvl(data_norm: pd.DataFrame, inherent_filtration: float) ->
 
     """
     # Open connection to database
-    conn = db_connect()[0]
+    conn = db_connect(db_name=corrections_db)[0]
 
     # Fetch entire HVL table
     hvl_data = pd.read_sql_query("SELECT * FROM hvl_combined", conn)
@@ -268,7 +270,7 @@ def fetch_and_append_hvl(data_norm: pd.DataFrame, inherent_filtration: float) ->
 def check_new_geometry(data_norm: pd.DataFrame) -> List[bool]:
     """Check which events has unchanged geometry since the event before.
 
-    This function is intented to calculate if new geometry parameters needs
+    This function is intended to calculate if new geometry parameters needs
     to be calculated, i.e., new beam, geometry positioning, field area and
     cell hit calculation.
 

--- a/src/pyskindose/settings/pyskindose_settings.py
+++ b/src/pyskindose/settings/pyskindose_settings.py
@@ -100,6 +100,7 @@ class PyskindoseSettings:
         self.estimate_k_tab = tmp[KEY_PARAM_ESTIMATE_K_TAB]
         self.phantom = PhantomSettings(ptm_dim=tmp["phantom"])
         self.plot = Plotsettings(plt_dict=tmp["plot"])
+        self.corrections_db_path = tmp.get("corrections_db_path", "corrections.db")
 
         self.normalization_settings = self._initialize_normalization_settings(normalization_settings)
 

--- a/src/pyskindose/settings_example.json
+++ b/src/pyskindose/settings_example.json
@@ -39,5 +39,6 @@
             "pad_thickness": 4,
             "unit": "cm"
         }
-    }
+    },
+    "corrections_db_path": "corrections.db"
 }

--- a/tests/integrationtests/test_corrections.py
+++ b/tests/integrationtests/test_corrections.py
@@ -16,7 +16,11 @@ def test_that_hvl_can_be_fetched_from_correction_database(allura_parsed, axiom_a
 
     for i in range(len(datas)):
         try:
-            fetch_and_append_hvl(data_norm=datas[i], inherent_filtration=3.1)
+            fetch_and_append_hvl(
+                data_norm=datas[i],
+                inherent_filtration=3.1,
+                corrections_db=example_settings.corrections_db_path
+            )
             actual.append(True)
         #
         except Exception:

--- a/tests/manual_tests/base_dev_settings.py
+++ b/tests/manual_tests/base_dev_settings.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from pyskindose import constants as c
 
 DEVELOPMENT_PARAMETERS = dict(
@@ -5,7 +7,8 @@ DEVELOPMENT_PARAMETERS = dict(
     mode=c.MODE_PLOT_PROCEDURE,
     # RDSR filename
     rdsr_filename="siemens_axiom_example_procedure.dcm",
-    # Irrading event index for mode='plot_event'
+    corrections_db_path=str((Path(__file__).parent / "corrections.db").absolute()),
+    # Irradiation event index for mode='plot_event'
     plot_event_index=12,
     # Set True to estimate table correction, or False to use measured k_tab
     estimate_k_tab=False,

--- a/tests/unittests/test_corrections.py
+++ b/tests/unittests/test_corrections.py
@@ -18,10 +18,14 @@ from pyskindose.corrections import (
     calculate_k_tab,
 )
 from pyskindose.geom_calc import fetch_and_append_hvl
+from pyskindose.settings import PyskindoseSettings
+
+from manual_tests.base_dev_settings import DEVELOPMENT_PARAMETERS
 
 P = Path(__file__).parent.parent.parent
 sys.path.insert(1, str(P.absolute()))
 
+PATH_TO_DB = PyskindoseSettings(DEVELOPMENT_PARAMETERS).corrections_db_path
 
 def test_fetch_hvl_from_database():
 
@@ -73,14 +77,18 @@ def test_fetch_correct_backscatter_correction_from_database():
 
 def test_fetch_correct_medium_correction_from_database():
     expected = [1.027, 1.026, 1.025, 1.025, 1.025]
-
+    
     data = {"kVp": [80], "HVL": [4.99]}
     data_norm = pd.DataFrame(data)
 
     # Tests if we get a value in expected, for cells with different field
     # sizes with filed side length in [5 to 35] cm.
-    actual = calculate_k_med(data_norm, np.square([6, 10, 20, 22, 32]), 0)
-
+    actual = calculate_k_med(
+        data_norm=data_norm,
+        field_area=np.square([6, 10, 20, 22, 32]),
+        event=0,
+        corrections_db=PATH_TO_DB,
+        )
     assert actual in expected
 
 
@@ -99,7 +107,12 @@ def test_fetch_correct_table_correction_from_database():
     )
 
     # Act
-    result = calculate_k_tab(data_norm=data_norm, estimate_k_tab=False, k_tab_val=0.8)
+    result = calculate_k_tab(
+        data_norm=data_norm,
+        estimate_k_tab=False,
+        k_tab_val=0.8,
+        corrections_db=PATH_TO_DB)
+    
     actual = result[0]
 
     # Assert
@@ -121,7 +134,11 @@ def test_fetch_correct_table_correction_from_database_when_machine_model_has_ext
     )
 
     # Act
-    result = calculate_k_tab(data_norm=data_norm, estimate_k_tab=False, k_tab_val=0.8)
+    result = calculate_k_tab(
+        data_norm=data_norm,
+        estimate_k_tab=False,
+        k_tab_val=0.8,
+        corrections_db=PATH_TO_DB)
     actual = result[0]
 
     # Assert

--- a/tests/unittests/test_corrections.py
+++ b/tests/unittests/test_corrections.py
@@ -27,7 +27,7 @@ def test_fetch_hvl_from_database():
 
     expected = 6.549
     data_norm = pd.DataFrame({"kVp": [81.4], "filter_thickness_Al": [0], "filter_thickness_Cu": [0.3]})
-    data_norm = fetch_and_append_hvl(data_norm=data_norm, inherent_filtration=3.1)
+    data_norm = fetch_and_append_hvl(data_norm=data_norm, inherent_filtration=3.1, corrections_db="corrections.db")
     actual = round(data_norm.HVL[0], 3)
     assert actual == expected
 


### PR DESCRIPTION
Adds a setting for the path to the corrections DB that is created the first time it is needed. This prevents a problem where the database could be created in one place and not be available later on when the data in the database was to be used.