### PR TITLE
Silence pydicom validation warnings

### DIFF
--- a/src/pyskindose/analyze_data.py
+++ b/src/pyskindose/analyze_data.py
@@ -63,9 +63,9 @@ def analyze_data(
     create_dose_map_plot(
         patient=patient,
         settings=settings,
-        dose_map=output[c.OUTPUT_KEY_DOSE_MAP]
-        if settings.mode in (c.MODE_CALCULATE_DOSE, c.MODE_PLOT_DOSEMAP)
-        else None,
+        dose_map=(
+            output[c.OUTPUT_KEY_DOSE_MAP] if settings.mode in (c.MODE_CALCULATE_DOSE, c.MODE_PLOT_DOSEMAP) else None
+        ),
     )
 
     if settings.output_format == c.RUN_ARGUMENTS_OUTPUT_HTML:

--- a/src/pyskindose/calculate_dose/add_correction_and_event_dose_to_output.py
+++ b/src/pyskindose/calculate_dose/add_correction_and_event_dose_to_output.py
@@ -73,10 +73,8 @@ def add_corrections_and_event_dose_to_output(
 
     logger.debug("Calculating reference point medium correction (air -> water)")
     k_med = calculate_k_med(
-        data_norm=normalized_data,
-        field_area=field_area,
-        event=event,
-        corrections_db=corrections_db)
+        data_norm=normalized_data, field_area=field_area, event=event, corrections_db=corrections_db
+    )
 
     output[c.OUTPUT_KEY_CORRECTION_BACK_SCATTER][event] = k_bs
     output[c.OUTPUT_KEY_CORRECTION_MEDIUM][event] = k_med

--- a/src/pyskindose/calculate_dose/calculate_dose.py
+++ b/src/pyskindose/calculate_dose/calculate_dose.py
@@ -75,7 +75,7 @@ def calculate_dose(
     normalized_data = fetch_and_append_hvl(
         data_norm=normalized_data,
         inherent_filtration=settings.inherent_filtration,
-        corrections_db=settings.corrections_db_path
+        corrections_db=settings.corrections_db_path,
     )
 
     # Check which irradiation events that contains updated
@@ -89,7 +89,7 @@ def calculate_dose(
         data_norm=normalized_data,
         estimate_k_tab=settings.estimate_k_tab,
         k_tab_val=settings.k_tab_val,
-        corrections_db=settings.corrections_db_path
+        corrections_db=settings.corrections_db_path,
     )
 
     total_number_of_events = len(normalized_data)
@@ -122,7 +122,7 @@ def calculate_dose(
         back_scatter_interpolation=back_scatter_interpolation,
         output=output_template,
         pbar=pbar(total=total_number_of_events, leave=False, desc="calculating skindose"),
-        corrections_db=settings.corrections_db_path
+        corrections_db=settings.corrections_db_path,
     )
 
     return patient, output

--- a/src/pyskindose/constants.py
+++ b/src/pyskindose/constants.py
@@ -33,6 +33,7 @@ KEY_PARAM_K_TAB_VAL = "k_tab_val"
 KEY_PARAM_PHANTOM_MODEL = "model"
 KEY_PARAM_HUMAN_MESH = "human_mesh"
 KEY_PARAM_INHERENT_FILTRATION = "inherent_filtration"
+KEY_PARAM_SILENCE_PYDICOM_WARNINGS = "silence_pydicom_warnings"
 
 DIMENSION_PLANE_LENGTH = "plane_length"
 DIMENSION_PLANE_RESOLUTION = "plane_resolution"

--- a/src/pyskindose/corrections.py
+++ b/src/pyskindose/corrections.py
@@ -176,7 +176,9 @@ def calculate_k_med(data_norm: pd.DataFrame, field_area: List[float], event: int
     return k_med
 
 
-def calculate_k_tab(data_norm: pd.DataFrame, corrections_db: str, estimate_k_tab: bool = False, k_tab_val: float = 0.8) -> List[float]:
+def calculate_k_tab(
+    data_norm: pd.DataFrame, corrections_db: str, estimate_k_tab: bool = False, k_tab_val: float = 0.8
+) -> List[float]:
     """Fetch table correction factor from database.
 
     This function fetches measured table correction factor as a function of

--- a/src/pyskindose/helpers/read_and_normalize_rdsr_data.py
+++ b/src/pyskindose/helpers/read_and_normalize_rdsr_data.py
@@ -29,7 +29,7 @@ def read_and_normalise_rdsr_data(rdsr_filepath: str, settings: PyskindoseSetting
     data_raw = pydicom.dcmread(rdsr_filepath)
 
     # parse RDSR data from raw .dicom file
-    data_parsed = rdsr_parser(data_raw)
+    data_parsed = rdsr_parser(data_raw, silence_pydicom_warnings=settings.silence_pydicom_warnings)
 
     # normalized rdsr for compliance with PySkinDose
     normalized_data = rdsr_normalizer(data_parsed, settings=settings)

--- a/src/pyskindose/plotting/create_geometry_plot.py
+++ b/src/pyskindose/plotting/create_geometry_plot.py
@@ -43,9 +43,11 @@ def create_geometry_plot(
     patient = Phantom(
         phantom_model=settings.phantom.model,
         phantom_dim=settings.phantom.dimension,
-        human_mesh=settings.phantom.human_mesh
-        if isinstance(settings.phantom.human_mesh, tuple)
-        else f"{settings.phantom.human_mesh}{c.PHANTOM_HUMAN_MESH_SPARSE_MODEL_ENDING if settings.mode == c.MODE_PLOT_PROCEDURE and settings.phantom.model == c.PHANTOM_MODEL_HUMAN else ''}",  # override dense .stl phantoms in plot_procedure .html plotting
+        human_mesh=(
+            settings.phantom.human_mesh
+            if isinstance(settings.phantom.human_mesh, tuple)
+            else f"{settings.phantom.human_mesh}{c.PHANTOM_HUMAN_MESH_SPARSE_MODEL_ENDING if settings.mode == c.MODE_PLOT_PROCEDURE and settings.phantom.model == c.PHANTOM_MODEL_HUMAN else ''}"
+        ),  # override dense .stl phantoms in plot_procedure .html plotting
     )
 
     # position objects in starting position

--- a/src/pyskindose/rdsr_parser.py
+++ b/src/pyskindose/rdsr_parser.py
@@ -17,7 +17,7 @@ from pyskindose.constants import (
 )
 
 
-def rdsr_parser(data_raw: pydicom.FileDataset) -> pd.DataFrame:
+def rdsr_parser(data_raw: pydicom.FileDataset, silence_pydicom_warnings=True) -> pd.DataFrame:
     """Parse event data from radiation dose structure reports (RDSR).
 
     Parameters
@@ -31,6 +31,9 @@ def rdsr_parser(data_raw: pydicom.FileDataset) -> pd.DataFrame:
         Parsed RDSR data from all irradiation events in the RDSR input file
 
     """
+    if silence_pydicom_warnings:
+        pydicom.config.settings.reading_validation_mode = pydicom.config.IGNORE
+
     # create list to store rdsr content from each irradiation event
     prodcedure_dicts = []
     # For each content in RDSR file

--- a/src/pyskindose/rdsr_parser.py
+++ b/src/pyskindose/rdsr_parser.py
@@ -17,7 +17,7 @@ from pyskindose.constants import (
 )
 
 
-def rdsr_parser(data_raw: pydicom.FileDataset, silence_pydicom_warnings=True) -> pd.DataFrame:
+def rdsr_parser(data_raw: pydicom.FileDataset, silence_pydicom_warnings=False) -> pd.DataFrame:
     """Parse event data from radiation dose structure reports (RDSR).
 
     Parameters

--- a/src/pyskindose/settings/pyskindose_settings.py
+++ b/src/pyskindose/settings/pyskindose_settings.py
@@ -10,6 +10,7 @@ from pyskindose.constants import (
     KEY_PARAM_K_TAB_VAL,
     KEY_PARAM_MODE,
     KEY_PARAM_RDSR_FILENAME,
+    KEY_PARAM_SILENCE_PYDICOM_WARNINGS,
     RUN_ARGUMENTS_OUTPUT_DICT,
     RUN_ARGUMENTS_OUTPUT_HTML,
     RUN_ARGUMENTS_OUTPUT_JSON,
@@ -96,6 +97,7 @@ class PyskindoseSettings:
         )
         self.k_tab_val = tmp[KEY_PARAM_K_TAB_VAL]
         self.inherent_filtration = tmp[KEY_PARAM_INHERENT_FILTRATION]
+        self.silence_pydicom_warnings = tmp[KEY_PARAM_SILENCE_PYDICOM_WARNINGS]
         self.rdsr_filename = tmp[KEY_PARAM_RDSR_FILENAME]
         self.estimate_k_tab = tmp[KEY_PARAM_ESTIMATE_K_TAB]
         self.phantom = PhantomSettings(ptm_dim=tmp["phantom"])
@@ -170,6 +172,7 @@ class PyskindoseSettings:
             f"\t[{color}]mode:\t{self.mode}[/{color}]\n"
             f"\t[{color}]rdsr_filename:\t{self.rdsr_filename}[/{color}]\n"
             f"\t[{color}]estimate_k_tab:\t{'True' if self.estimate_k_tab else 'False'}[/{color}]\n"
+            f"\t[{color}]silence_pydicom_warnings:\t{'True' if self.silence_pydicom_warnings else 'False'}[/{color}]\n"
             f"\n{phantom_settings_string}"
             f"\n{plot_settings_string}"
             f"\n{normalization_settings_string}"

--- a/src/pyskindose/settings_example.json
+++ b/src/pyskindose/settings_example.json
@@ -5,6 +5,7 @@
     "estimate_k_tab": false,
     "k_tab_val": 0.8,
     "inherent_filtration": 3.1,
+    "silence_pydicom_warnings": true,
     "plot": {
         "dark_mode": true,
         "notebook_mode": false,

--- a/tests/integrationtests/conftest.py
+++ b/tests/integrationtests/conftest.py
@@ -19,6 +19,7 @@ def example_settings() -> PyskindoseSettings:
         "plot_event_index": 12,
         "estimate_k_tab": False,
         "inherent_filtration": 3.1,
+        "silence_pydicom_warnings": True,
         "k_tab_val": 0.8,
         "plot": {
             "interactivity": True,

--- a/tests/integrationtests/test_corrections.py
+++ b/tests/integrationtests/test_corrections.py
@@ -17,9 +17,7 @@ def test_that_hvl_can_be_fetched_from_correction_database(allura_parsed, axiom_a
     for i in range(len(datas)):
         try:
             fetch_and_append_hvl(
-                data_norm=datas[i],
-                inherent_filtration=3.1,
-                corrections_db=example_settings.corrections_db_path
+                data_norm=datas[i], inherent_filtration=3.1, corrections_db=example_settings.corrections_db_path
             )
             actual.append(True)
         #

--- a/tests/manual_tests/base_dev_settings.py
+++ b/tests/manual_tests/base_dev_settings.py
@@ -16,6 +16,8 @@ DEVELOPMENT_PARAMETERS = dict(
     k_tab_val=0.8,
     # x-ray tube inherent filtration in mmAl
     inherent_filtration=3.1,
+    # Silence reading_validation_mode warnings in pydicom
+    silence_pydicom_warnings=True,
     # plot settings
     plot={
         "interactivity": True,

--- a/tests/manual_tests/notebook_tests/notebook_base_dev_settings.py
+++ b/tests/manual_tests/notebook_tests/notebook_base_dev_settings.py
@@ -12,6 +12,8 @@ DEVELOPMENT_PARAMETERS = dict(
     # plot settings
     # x-ray tube inherent filtration in mmAl
     inherent_filtration=3.1,
+    # Silence reading_validation_mode warnings in pydicom
+    silence_pydicom_warnings=True,
     plot={
         # toggle interactive/static dose map mode.
         c.MODE_INTERACTIVITY: True,

--- a/tests/unittests/test_corrections.py
+++ b/tests/unittests/test_corrections.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
+from manual_tests.base_dev_settings import DEVELOPMENT_PARAMETERS
 from pyskindose.constants import (
     KEY_NORMALIZATION_ACQUISITION_PLANE,
     KEY_NORMALIZATION_FILTER_SIZE_ALUMINUM,
@@ -20,12 +21,11 @@ from pyskindose.corrections import (
 from pyskindose.geom_calc import fetch_and_append_hvl
 from pyskindose.settings import PyskindoseSettings
 
-from manual_tests.base_dev_settings import DEVELOPMENT_PARAMETERS
-
 P = Path(__file__).parent.parent.parent
 sys.path.insert(1, str(P.absolute()))
 
 PATH_TO_DB = PyskindoseSettings(DEVELOPMENT_PARAMETERS).corrections_db_path
+
 
 def test_fetch_hvl_from_database():
 
@@ -77,7 +77,7 @@ def test_fetch_correct_backscatter_correction_from_database():
 
 def test_fetch_correct_medium_correction_from_database():
     expected = [1.027, 1.026, 1.025, 1.025, 1.025]
-    
+
     data = {"kVp": [80], "HVL": [4.99]}
     data_norm = pd.DataFrame(data)
 
@@ -88,7 +88,7 @@ def test_fetch_correct_medium_correction_from_database():
         field_area=np.square([6, 10, 20, 22, 32]),
         event=0,
         corrections_db=PATH_TO_DB,
-        )
+    )
     assert actual in expected
 
 
@@ -107,12 +107,8 @@ def test_fetch_correct_table_correction_from_database():
     )
 
     # Act
-    result = calculate_k_tab(
-        data_norm=data_norm,
-        estimate_k_tab=False,
-        k_tab_val=0.8,
-        corrections_db=PATH_TO_DB)
-    
+    result = calculate_k_tab(data_norm=data_norm, estimate_k_tab=False, k_tab_val=0.8, corrections_db=PATH_TO_DB)
+
     actual = result[0]
 
     # Assert
@@ -134,11 +130,7 @@ def test_fetch_correct_table_correction_from_database_when_machine_model_has_ext
     )
 
     # Act
-    result = calculate_k_tab(
-        data_norm=data_norm,
-        estimate_k_tab=False,
-        k_tab_val=0.8,
-        corrections_db=PATH_TO_DB)
+    result = calculate_k_tab(data_norm=data_norm, estimate_k_tab=False, k_tab_val=0.8, corrections_db=PATH_TO_DB)
     actual = result[0]
 
     # Assert


### PR DESCRIPTION
With the suggested changes, you can silence annoying pydicom warning messages by setting `settings.silence_pydicom_warnings = True` in PyskindoseSettings. All relevant test and development setting files have been updated accordingly.

If you're using rdsr_parser as a standalone function, you can suppress warnings by setting its silence_pydicom_warnings attribute to True. For example: `data_parsed = rdsr_parser(data_raw, silence_pydicom_warnings=True)`.

