### PR TITLE
Norm settings bug

### DIFF
--- a/src/pyskindose/settings/rotation_direction.py
+++ b/src/pyskindose/settings/rotation_direction.py
@@ -31,21 +31,44 @@ class RotationDirection:
         self.At3: Optional[int] = None if directions is None else self._get_direction_as_value(directions["At3"])
 
     def update_rotation_direction(self, directions: Dict[str, str]):
-        self.Ap1 = self._get_direction_as_value(directions["Ap1"]) if self.Ap1 is None else self._get_direction_as_value(self.Ap1)
-        self.Ap2 = self._get_direction_as_value(directions["Ap2"]) if self.Ap2 is None else self._get_direction_as_value(self.Ap2)
-        self.Ap3 = self._get_direction_as_value(directions["Ap3"]) if self.Ap3 is None else self._get_direction_as_value(self.Ap3)
-        self.At1 = self._get_direction_as_value(directions["At1"]) if self.At1 is None else self._get_direction_as_value(self.At1)
-        self.At2 = self._get_direction_as_value(directions["At2"]) if self.At2 is None else self._get_direction_as_value(self.At2)
-        self.At3 = self._get_direction_as_value(directions["At3"]) if self.At3 is None else self._get_direction_as_value(self.At3)
+        self.Ap1 = (
+            self._get_direction_as_value(directions["Ap1"])
+            if self.Ap1 is None
+            else self._get_direction_as_value(self.Ap1)
+        )
+        self.Ap2 = (
+            self._get_direction_as_value(directions["Ap2"])
+            if self.Ap2 is None
+            else self._get_direction_as_value(self.Ap2)
+        )
+        self.Ap3 = (
+            self._get_direction_as_value(directions["Ap3"])
+            if self.Ap3 is None
+            else self._get_direction_as_value(self.Ap3)
+        )
+        self.At1 = (
+            self._get_direction_as_value(directions["At1"])
+            if self.At1 is None
+            else self._get_direction_as_value(self.At1)
+        )
+        self.At2 = (
+            self._get_direction_as_value(directions["At2"])
+            if self.At2 is None
+            else self._get_direction_as_value(self.At2)
+        )
+        self.At3 = (
+            self._get_direction_as_value(directions["At3"])
+            if self.At3 is None
+            else self._get_direction_as_value(self.At3)
+        )
 
     @staticmethod
     def _get_direction_as_value(direction: Union[str, int]):
-        
+
         if direction in (-1, +1):
             return direction
 
-        if direction in ('+', '-'):
+        if direction in ("+", "-"):
             return 1 if direction == "+" else -1
 
         raise ValueError(f"The direction must be given as '+', '-', 1, or -1, but was given as {direction}")
-

--- a/src/pyskindose/settings/rotation_direction.py
+++ b/src/pyskindose/settings/rotation_direction.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 
 class RotationDirection:
@@ -31,16 +31,21 @@ class RotationDirection:
         self.At3: Optional[int] = None if directions is None else self._get_direction_as_value(directions["At3"])
 
     def update_rotation_direction(self, directions: Dict[str, str]):
-        self.Ap1 = self._get_direction_as_value(directions["Ap1"])
-        self.Ap2 = self._get_direction_as_value(directions["Ap2"])
-        self.Ap3 = self._get_direction_as_value(directions["Ap3"])
-        self.At1 = self._get_direction_as_value(directions["At1"])
-        self.At2 = self._get_direction_as_value(directions["At2"])
-        self.At3 = self._get_direction_as_value(directions["At3"])
+        self.Ap1 = self._get_direction_as_value(directions["Ap1"]) if self.Ap1 is None else self._get_direction_as_value(self.Ap1)
+        self.Ap2 = self._get_direction_as_value(directions["Ap2"]) if self.Ap2 is None else self._get_direction_as_value(self.Ap2)
+        self.Ap3 = self._get_direction_as_value(directions["Ap3"]) if self.Ap3 is None else self._get_direction_as_value(self.Ap3)
+        self.At1 = self._get_direction_as_value(directions["At1"]) if self.At1 is None else self._get_direction_as_value(self.At1)
+        self.At2 = self._get_direction_as_value(directions["At2"]) if self.At2 is None else self._get_direction_as_value(self.At2)
+        self.At3 = self._get_direction_as_value(directions["At3"]) if self.At3 is None else self._get_direction_as_value(self.At3)
 
     @staticmethod
-    def _get_direction_as_value(direction: str):
-        if direction not in ("+", "-"):
-            raise ValueError(f"The direction must be given as '+' or '-' but was given as {direction}")
+    def _get_direction_as_value(direction: Union[str, int]):
+        
+        if direction in (-1, +1):
+            return direction
 
-        return 1 if direction == "+" else -1
+        if direction in ('+', '-'):
+            return 1 if direction == "+" else -1
+
+        raise ValueError(f"The direction must be given as '+', '-', 1, or -1, but was given as {direction}")
+

--- a/src/pyskindose/settings/translation_direction.py
+++ b/src/pyskindose/settings/translation_direction.py
@@ -32,9 +32,9 @@ class TranslationDirection:
         self.z = None if directions is None else self._get_direction_as_value(directions["z"])
 
     def update_translation_direction(self, directions: Dict[str, str]):
-        self.x = self._get_direction_as_value(directions["x"])
-        self.y = self._get_direction_as_value(directions["y"])
-        self.z = self._get_direction_as_value(directions["z"])
+        self.x = self._get_direction_as_value(directions["x"]) if self.x is None else self.x
+        self.y = self._get_direction_as_value(directions["y"]) if self.y is None else self.y
+        self.z = self._get_direction_as_value(directions["z"]) if self.z is None else self.z
 
     @staticmethod
     def _get_direction_as_value(direction: str):

--- a/src/pyskindose/settings/translation_offset.py
+++ b/src/pyskindose/settings/translation_offset.py
@@ -34,6 +34,6 @@ class TranslationOffset:
         self.z: float = offset.get("z")
 
     def update_translation_offset(self, offset: Dict[str, float]):
-        self.x = float(offset["x"])
-        self.y = float(offset["y"])
-        self.z = float(offset["z"])
+        self.x = float(offset["x"]) if self.x is None else self.x
+        self.y = float(offset["y"]) if self.y is None else self.y
+        self.z = float(offset["z"]) if self.z is None else self.z

--- a/tests/integrationtests/test_rdsr_normalizer.py
+++ b/tests/integrationtests/test_rdsr_normalizer.py
@@ -89,7 +89,6 @@ def test_rdsr_normalizer_correctly_handles_events_without_filter(axiom_artis_par
     parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_TYPE] = "NoFilter"
     parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_MIN] = 0.0
     parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_MAX] = 0.0
-    
 
     # Act
     normalized_data = rdsr_normalizer(data_parsed=parsed_data_with_nofilter_events, settings=example_settings)

--- a/tests/integrationtests/test_rdsr_normalizer.py
+++ b/tests/integrationtests/test_rdsr_normalizer.py
@@ -84,12 +84,12 @@ def test_rdsr_normalizer_correctly_handles_events_without_filter(axiom_artis_par
         0.9,
         0.6,
     ]
-
     parsed_data_with_nofilter_events: pd.DataFrame = axiom_artis_parsed.copy()
-    parsed_data_with_nofilter_events[KEY_RDSR_FILTER_MATERIAL][0] = np.nan
-    parsed_data_with_nofilter_events[KEY_RDSR_FILTER_TYPE][0] = "NoFilter"
-    parsed_data_with_nofilter_events[KEY_RDSR_FILTER_MIN][0] = 0.0
-    parsed_data_with_nofilter_events[KEY_RDSR_FILTER_MAX][0] = 0.0
+    parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_MATERIAL] = np.nan
+    parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_TYPE] = "NoFilter"
+    parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_MIN] = 0.0
+    parsed_data_with_nofilter_events.loc[0, KEY_RDSR_FILTER_MAX] = 0.0
+    
 
     # Act
     normalized_data = rdsr_normalizer(data_parsed=parsed_data_with_nofilter_events, settings=example_settings)

--- a/tests/manual_tests/manual_test_all_modes.py
+++ b/tests/manual_tests/manual_test_all_modes.py
@@ -1,8 +1,7 @@
-import manual_test_plot_setup
-import manual_test_plot_event
-import manual_test_plot_procedure
 import manual_test_calculate_dose_interactive
 import manual_test_calculate_dose_static
-
+import manual_test_plot_event
+import manual_test_plot_procedure
+import manual_test_plot_setup
 
 print("all modes executed")

--- a/tests/manual_tests/manual_test_all_modes.py
+++ b/tests/manual_tests/manual_test_all_modes.py
@@ -1,13 +1,8 @@
-import manual_test_calculate_dose_interactive
-import manual_test_calculate_dose_static
+import manual_test_plot_setup
 import manual_test_plot_event
 import manual_test_plot_procedure
-import manual_test_plot_setup
+import manual_test_calculate_dose_interactive
+import manual_test_calculate_dose_static
 
-manual_test_plot_setup
-manual_test_plot_event
-manual_test_plot_procedure
-manual_test_calculate_dose_static
-manual_test_calculate_dose_interactive
 
 print("all modes executed")


### PR DESCRIPTION
This update resolves the issue preventing users from manually adjusting normalization settings.

Previously, the `normalization_settings.json` file would overwrite any user-defined normalization entries. With this fix, users can now manually tune the normalization settings. For example, by setting `settings.normalization_settings.trans_offset.x = 50,` users can move the table 50 cm in the x direction.

### Additional Changes in This Pull Request
In addition to the main updates, this pull request includes the following minor improvements:

Resolved an issue causing "double execution" of manual tests in `manual_test_all_modes.py`.
Addressed a `FutureWarning` from Pandas in `test_rdsr_normalizer.py.`
